### PR TITLE
feat: Add caching layer to ApiService

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
         "lint": "eslint ./ --fix",
         "deploy": "vite build && firebase deploy --only hosting --project api-9176249411662404922-339889",
         "deploy:beta": "vite build && firebase hosting:channel:deploy beta --expires 14d --project api-9176249411662404922-339889",
+        "test": "vitest",
+        "test:unit": "vitest",
+        "coverage": "vitest run --coverage",
         "test:e2e": "playwright test",
         "test:perf": "lhci autorun"
     },
@@ -34,13 +37,17 @@
         "@playwright/test": "^1.53.1",
         "@types/node": "24.0.7",
         "@vitejs/plugin-vue": "6.0.0",
+        "@vitest/ui": "^3.2.4",
         "@vue/cli-plugin-typescript": "5.0.8",
+        "@vue/test-utils": "^2.4.6",
+        "happy-dom": "^18.0.1",
         "playwright": "^1.53.1",
         "prettier": "3.6.2",
         "sass-embedded": "^1.89.2",
         "ts-loader": "9.5.2",
         "typescript": "5.8.3",
-        "vite": "7.0.0"
+        "vite": "7.0.0",
+        "vitest": "^3.2.4"
     },
     "type": "module"
 }

--- a/src/services/cacheService.ts
+++ b/src/services/cacheService.ts
@@ -1,0 +1,93 @@
+interface CacheEntry<T> {
+    data: T;
+    timestamp: number;
+    ttl: number; // Time To Live in milliseconds
+}
+
+/**
+ * Provides a simple in-memory caching mechanism with Time-To-Live (TTL) support.
+ */
+export class CacheService {
+    private cache: Map<string, CacheEntry<unknown>> = new Map();
+
+    constructor() {}
+
+    /**
+     * Retrieves an entry from the cache.
+     * Returns null if the entry does not exist or has passed its TTL.
+     * Expired entries are automatically removed from the cache upon access attempt.
+     * @template T The expected type of the cached data.
+     * @param {string} key The cache key.
+     * @returns {T | null} The cached data, or null if not found or expired.
+     */
+    get<T>(key: string): T | null {
+        const entry = this.cache.get(key);
+        if (!entry) {
+            return null;
+        }
+
+        const now = Date.now();
+        if (now - entry.timestamp > entry.ttl) {
+            this.cache.delete(key); // Entry expired
+            return null;
+        }
+
+        return entry.data as T;
+    }
+
+    /**
+     * Adds or updates an entry in the cache with a specific Time-To-Live (TTL).
+     * If an entry with the same key already exists, it will be overwritten.
+     * @template T The type of data to be cached.
+     * @param {string} key The cache key.
+     * @param {T} data The data to cache.
+     * @param {number} [ttl=3600000] Time To Live in milliseconds. Defaults to 1 hour.
+     */
+    set<T>(key: string, data: T, ttl: number = 3600000): void { // Default TTL: 1 hour
+        const timestamp = Date.now();
+        this.cache.set(key, { data, timestamp, ttl });
+    }
+
+    /**
+     * Deletes an entry from the cache.
+     * If the key does not exist, this operation has no effect.
+     * @param {string} key The cache key to delete.
+     */
+    delete(key: string): void {
+        this.cache.delete(key);
+    }
+
+    /**
+     * Checks if a valid (non-expired) entry exists in the cache.
+     * Expired entries are automatically removed if found during this check.
+     * @param {string} key The cache key to check.
+     * @returns {boolean} True if a valid entry exists, false otherwise.
+     */
+    has(key: string): boolean {
+        const entry = this.cache.get(key);
+        if (!entry) {
+            return false;
+        }
+
+        const now = Date.now();
+        if (now - entry.timestamp > entry.ttl) {
+            this.cache.delete(key); // Entry expired
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Clears the entire cache, removing all entries.
+     */
+    clear(): void {
+        this.cache.clear();
+    }
+}
+
+/**
+ * Singleton instance of the CacheService.
+ * @exports cacheService
+ */
+export const cacheService = new CacheService();

--- a/tests/unit/services/apiService.spec.ts
+++ b/tests/unit/services/apiService.spec.ts
@@ -1,0 +1,229 @@
+import ApiService from '@/services/apiService';
+import { cacheService, CacheService } from '@/services/cacheService';
+import { getApiUrl } from '@/helpers/app';
+
+// Mock a global fetch
+global.fetch = vi.fn();
+
+// Mock getApiUrl
+vi.mock('@/helpers/app', () => ({
+    getApiUrl: vi.fn(() => 'https://api.example.com/'),
+    env: vi.fn((key) => {
+        if (key === 'VITE_APP_APP_ENV') return 'test'; // Or 'local' to enable dev logs
+        return '';
+    }),
+}));
+
+// Spy on cacheService methods
+vi.spyOn(cacheService, 'get');
+vi.spyOn(cacheService, 'set');
+vi.spyOn(cacheService, 'delete');
+vi.spyOn(cacheService, 'clear');
+
+
+describe('ApiService Caching', () => {
+    const mockSuccessResponse = (data: unknown) => ({
+        ok: true,
+        json: () => Promise.resolve(data),
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+    });
+
+    const mockErrorResponse = (data: unknown, status: number) => ({
+        ok: false,
+        status,
+        json: () => Promise.resolve(data),
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks(); // Clears mock calls, but not their implementations
+        cacheService.clear(); // Ensure cache is clean before each test
+        (fetch as vi.Mock).mockReset(); // Reset fetch mocks
+    });
+
+    it('should fetch data from API if not in cache and store it', async () => {
+        const url = 'test/data';
+        const mockData = { message: 'success' };
+        (fetch as vi.Mock).mockResolvedValue(mockSuccessResponse(mockData));
+
+        const result = await ApiService.get(url);
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(fetch).toHaveBeenCalledWith('https://api.example.com/test/data', expect.anything());
+        expect(result).toEqual(mockData);
+        const cacheKey = `GET:${getApiUrl()}${url}`;
+        expect(cacheService.get).toHaveBeenCalledWith(cacheKey);
+        expect(cacheService.set).toHaveBeenCalledWith(cacheKey, mockData, 3600000); // Default TTL
+    });
+
+    it('should return data from cache if available and not expired', async () => {
+        const url = 'cached/data';
+        const cachedData = { message: 'from cache' };
+        const cacheKey = `GET:${getApiUrl()}${url}`;
+        cacheService.set(cacheKey, cachedData, 3600000); // Pre-populate cache
+
+        // Reset call count for `set` from pre-population
+        (cacheService.set as vi.Mock).mockClear();
+
+        const result = await ApiService.get(url);
+
+        expect(fetch).not.toHaveBeenCalled();
+        expect(result).toEqual(cachedData);
+        expect(cacheService.get).toHaveBeenCalledWith(cacheKey);
+        expect(cacheService.set).not.toHaveBeenCalled(); // Should not set again if fetched from cache
+    });
+
+    it('should fetch from API if cache is skipped and store it if not skipped', async () => {
+        const url = 'skip/cache';
+        const mockData = { message: 'fetched bypassing read cache' };
+        (fetch as vi.Mock).mockResolvedValue(mockSuccessResponse(mockData));
+        const cacheKey = `GET:${getApiUrl()}${url}`;
+
+        // First, ensure it's not in cache
+        expect(cacheService.get(cacheKey)).toBeNull();
+
+        const result = await ApiService.get(url, {}, true, true); // skipCache = true
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(mockData);
+        expect(cacheService.get).toHaveBeenCalledWith(cacheKey); // get is still called to check
+        expect(cacheService.set).not.toHaveBeenCalled(); // Should not store if skipCache is true
+
+        // Try again, skipCache = false (default)
+        (fetch as vi.Mock).mockClear(); // Clear fetch mock for the next call
+         await ApiService.get(url, {}, true, false); // skipCache = false
+         expect(fetch).toHaveBeenCalledTimes(1); // Fetched again because it wasn't stored
+         expect(cacheService.set).toHaveBeenCalledWith(cacheKey, mockData, 3600000);
+    });
+
+    it('should fetch from API if cache is skipped (even if data exists) and not store it', async () => {
+        const url = 'skip/existing/cache';
+        const initialData = {message: "I'm in cache"};
+        const fetchedData = { message: 'fetched bypassing read cache' };
+        const cacheKey = `GET:${getApiUrl()}${url}`;
+
+        cacheService.set(cacheKey, initialData, 3600000); // Pre-populate cache
+        (fetch as vi.Mock).mockResolvedValue(mockSuccessResponse(fetchedData));
+        (cacheService.set as vi.Mock).mockClear(); // clear previous set call
+
+        const result = await ApiService.get(url, {}, true, true); // skipCache = true
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(fetchedData); // Should be the newly fetched data
+        expect(cacheService.get).not.toHaveBeenCalled(); // Should NOT have been called if skipCache is true
+        expect(cacheService.set).not.toHaveBeenCalled(); // Should not store if skipCache is true
+
+        // Verify cache still holds the original data
+        expect(cacheService.get(cacheKey)).toEqual(initialData);
+    });
+
+
+    it('should use custom TTL when provided', async () => {
+        const url = 'custom/ttl';
+        const mockData = { message: 'custom ttl data' };
+        const customTTL = 5000; // 5 seconds
+        (fetch as vi.Mock).mockResolvedValue(mockSuccessResponse(mockData));
+        const cacheKey = `GET:${getApiUrl()}${url}`;
+
+        await ApiService.get(url, {}, true, false, customTTL);
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(cacheService.set).toHaveBeenCalledWith(cacheKey, mockData, customTTL);
+    });
+
+    it('should fetch from API if cached data is expired', async () => {
+        vi.useFakeTimers();
+        const url = 'expired/data';
+        const cachedData = { message: 'expired cache data' };
+        const freshData = { message: 'fresh data from API' };
+        const ttl = 1000; // 1 second
+        const cacheKey = `GET:${getApiUrl()}${url}`;
+
+        cacheService.set(cacheKey, cachedData, ttl);
+        (cacheService.set as vi.Mock).mockClear(); // Clear set from initial caching
+
+        (fetch as vi.Mock).mockResolvedValue(mockSuccessResponse(freshData));
+
+        // Advance time beyond TTL
+        vi.advanceTimersByTime(ttl + 100);
+
+        const result = await ApiService.get(url);
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(freshData);
+        expect(cacheService.get).toHaveBeenCalledWith(cacheKey); // Called, but returned null
+        expect(cacheService.set).toHaveBeenCalledWith(cacheKey, freshData, 3600000); // Stored fresh data
+        vi.useRealTimers();
+    });
+
+    it('should invalidate a specific cache entry', async () => {
+        const url = 'invalidate/me';
+        const mockData = { id: 1, content: 'some data' };
+        const cacheKey = `GET:${getApiUrl()}${url}`;
+
+        // Populate cache
+        cacheService.set(cacheKey, mockData, 3600000);
+        expect(cacheService.get(cacheKey)).toEqual(mockData);
+
+        ApiService.invalidateCache(url);
+
+        expect(cacheService.delete).toHaveBeenCalledWith(cacheKey);
+        expect(cacheService.get(cacheKey)).toBeNull(); // Should be gone from actual cache
+    });
+
+    it('invalidateCache should handle non-prefixed URLs if specified', () => {
+        const url = 'https://some.external.api/data';
+        const mockData = { value: "external data" };
+        const cacheKey = `GET:${url}`; // No api.example.com prefix
+
+        cacheService.set(cacheKey, mockData, 3600000);
+        expect(cacheService.get(cacheKey)).toEqual(mockData);
+
+        ApiService.invalidateCache(url, false); // prefix = false
+
+        expect(cacheService.delete).toHaveBeenCalledWith(cacheKey);
+        expect(cacheService.get(cacheKey)).toBeNull();
+    });
+
+    it('clearApiCache should remove all GET request entries from cache', () => {
+        // Add some GET entries
+        cacheService.set(`GET:${getApiUrl()}data1`, { item: 1 });
+        cacheService.set(`GET:${getApiUrl()}data2`, { item: 2 });
+        cacheService.set(`GET:https://other.com/data3`, { item: 3 }); // Non-prefixed GET
+        // Add a non-GET entry (though ApiService wouldn't create this, CacheService allows it)
+        cacheService.set('POST:/some/other/key', { item: 'not a get' });
+
+        expect(cacheService.has(`GET:${getApiUrl()}data1`)).toBe(true);
+        expect(cacheService.has(`POST:/some/other/key`)).toBe(true);
+
+        ApiService.clearApiCache();
+
+        // Check that all relevant keys were attempted to be deleted
+        // The exact calls depend on the internal implementation of clearApiCache (iteration order)
+        // So we check if delete was called for each key that should be deleted.
+        expect(cacheService.delete).toHaveBeenCalledWith(`GET:${getApiUrl()}data1`);
+        expect(cacheService.delete).toHaveBeenCalledWith(`GET:${getApiUrl()}data2`);
+        expect(cacheService.delete).toHaveBeenCalledWith(`GET:https://other.com/data3`);
+
+        // Verify they are actually gone
+        expect(cacheService.get(`GET:${getApiUrl()}data1`)).toBeNull();
+        expect(cacheService.get(`GET:${getApiUrl()}data2`)).toBeNull();
+        expect(cacheService.get(`GET:https://other.com/data3`)).toBeNull();
+
+        // Verify the non-GET entry is still there
+        expect(cacheService.get('POST:/some/other/key')).toEqual({ item: 'not a get' });
+    });
+
+    it('should not cache failed API responses', async () => {
+        const url = 'failing/request';
+        const errorResponse = { type: "ERROR", message: 'Failed to fetch' };
+        (fetch as vi.Mock).mockResolvedValue(mockErrorResponse(errorResponse, 500));
+        const cacheKey = `GET:${getApiUrl()}${url}`;
+
+        await expect(ApiService.get(url)).rejects.toBeDefined();
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(cacheService.get).toHaveBeenCalledWith(cacheKey);
+        expect(cacheService.set).not.toHaveBeenCalled(); // Should not cache on error
+    });
+});

--- a/tests/unit/services/cacheService.spec.ts
+++ b/tests/unit/services/cacheService.spec.ts
@@ -1,0 +1,165 @@
+import { CacheService } from '@/services/cacheService'; // Adjust path as necessary
+
+describe('CacheService', () => {
+    let cacheService: CacheService;
+
+    beforeEach(() => {
+        cacheService = new CacheService();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers(); // Restore real timers after each test
+    });
+
+    it('should instantiate', () => {
+        expect(cacheService).toBeInstanceOf(CacheService);
+    });
+
+    it('should set and get a cache entry', () => {
+        const key = 'testKey';
+        const data = { message: 'Hello, World!' };
+        cacheService.set(key, data);
+        expect(cacheService.get(key)).toEqual(data);
+    });
+
+    it('should return null for a non-existent key', () => {
+        expect(cacheService.get('nonExistentKey')).toBeNull();
+    });
+
+    it('should return null for an expired entry', () => {
+        vi.useFakeTimers();
+        const key = 'expiredKey';
+        const data = { value: 123 };
+        const ttl = 1000; // 1 second
+        cacheService.set(key, data, ttl);
+
+        // Advance time by TTL + 1 millisecond
+        vi.advanceTimersByTime(ttl + 1);
+
+        expect(cacheService.get(key)).toBeNull();
+        vi.useRealTimers();
+    });
+
+    it('should correctly report presence of a key with has()', () => {
+        const key = 'hasKey';
+        const data = 'test data';
+        cacheService.set(key, data);
+        expect(cacheService.has(key)).toBe(true);
+    });
+
+    it('should correctly report absence of a non-existent key with has()', () => {
+        expect(cacheService.has('nonExistentKeyForHas')).toBe(false);
+    });
+
+    it('should correctly report absence of an expired key with has()', () => {
+        vi.useFakeTimers();
+        const key = 'expiredKeyForHas';
+        const data = { value: 456 };
+        const ttl = 500; // 0.5 seconds
+        cacheService.set(key, data, ttl);
+
+        vi.advanceTimersByTime(ttl + 100); // Advance time beyond TTL
+
+        expect(cacheService.has(key)).toBe(false);
+        vi.useRealTimers(); // Restore real timers
+    });
+
+    it('should not return an expired entry even if checked with has() first', () => {
+        vi.useFakeTimers();
+        const key = 'expiredHasThenGetKey';
+        const data = { detail: "check expiration logic" };
+        const ttl = 2000; // 2 seconds
+        cacheService.set(key, data, ttl);
+
+        // Entry should be valid initially
+        expect(cacheService.has(key)).toBe(true);
+        expect(cacheService.get(key)).toEqual(data);
+
+        // Advance time by TTL + 1 millisecond
+        vi.advanceTimersByTime(ttl + 1);
+
+        // Now 'has' should return false and delete it
+        expect(cacheService.has(key)).toBe(false);
+        // Consequently, 'get' should also return null
+        expect(cacheService.get(key)).toBeNull();
+        vi.useRealTimers();
+      });
+
+    it('should delete a cache entry', () => {
+        const key = 'deleteKey';
+        const data = { item: 'to be deleted' };
+        cacheService.set(key, data);
+        expect(cacheService.has(key)).toBe(true);
+        cacheService.delete(key);
+        expect(cacheService.has(key)).toBe(false);
+        expect(cacheService.get(key)).toBeNull();
+    });
+
+    it('should clear all cache entries', () => {
+        cacheService.set('key1', 'data1');
+        cacheService.set('key2', { value: 'data2' });
+        expect(cacheService.has('key1')).toBe(true);
+        expect(cacheService.has('key2')).toBe(true);
+        cacheService.clear();
+        expect(cacheService.has('key1')).toBe(false);
+        expect(cacheService.has('key2')).toBe(false);
+        expect(cacheService.get('key1')).toBeNull();
+        expect(cacheService.get('key2')).toBeNull();
+    });
+
+    it('should respect different TTLs for different entries', () => {
+        vi.useFakeTimers();
+        const keyShort = 'shortLived';
+        const dataShort = 'goes away soon';
+        const ttlShort = 100; // 0.1 second
+
+        const keyLong = 'longLived';
+        const dataLong = 'stays longer';
+        const ttlLong = 2000; // 2 seconds
+
+        cacheService.set(keyShort, dataShort, ttlShort);
+        cacheService.set(keyLong, dataLong, ttlLong);
+
+        // Advance time by 150ms
+        vi.advanceTimersByTime(150);
+
+        expect(cacheService.get(keyShort)).toBeNull(); // Expired
+        expect(cacheService.has(keyShort)).toBe(false);
+        expect(cacheService.get(keyLong)).toEqual(dataLong); // Still valid
+        expect(cacheService.has(keyLong)).toBe(true);
+
+        // Advance time by another 1900ms (total 2050ms from start)
+        vi.advanceTimersByTime(1900);
+        expect(cacheService.get(keyLong)).toBeNull(); // Now expired
+        expect(cacheService.has(keyLong)).toBe(false);
+
+        vi.useRealTimers();
+    });
+
+    it('set should overwrite an existing key and update its TTL', () => {
+        vi.useFakeTimers();
+        const key = 'overwriteKey';
+        const initialData = { version: 1 };
+        const initialTtl = 1000; // 1 second
+        cacheService.set(key, initialData, initialTtl);
+
+        expect(cacheService.get(key)).toEqual(initialData);
+
+        const newData = { version: 2 };
+        const newTtl = 5000; // 5 seconds
+        cacheService.set(key, newData, newTtl); // Overwrite with new data and TTL
+
+        expect(cacheService.get(key)).toEqual(newData);
+
+        // Advance time by initial TTL + buffer (e.g., 1200ms)
+        // If TTL wasn't updated, it would be null.
+        vi.advanceTimersByTime(1200);
+        expect(cacheService.get(key)).toEqual(newData); // Should still be there due to new TTL
+
+        // Advance time past new TTL (e.g., 4000ms more, total 5200ms)
+        vi.advanceTimersByTime(4000);
+        expect(cacheService.get(key)).toBeNull(); // Now it should be gone
+
+        vi.useRealTimers();
+    });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vitest/config';
+import vue from '@vitejs/plugin-vue';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    globals: true,
+    environment: 'happy-dom', // or 'jsdom'
+    setupFiles: [], // if you have any setup files
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/cypress/**',
+      '**/.{idea,git,cache,output,temp}/**',
+      '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
+      '**/tests/e2e/**' // Exclude e2e tests
+    ],
+    coverage: {
+      provider: 'v8', // or 'istanbul'
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
- Implemented CacheService for in-memory caching with TTL.
- Integrated caching into ApiService GET requests.
- Added cache invalidation (manual and time-based).
- Included options to skip cache and set custom TTL per request.
- Added unit tests for CacheService and ApiService caching logic.
- Documented new services and methods with JSDoc.

Fixes #9 